### PR TITLE
Unit Tests + Transaction Call Data

### DIFF
--- a/res/openapi.json
+++ b/res/openapi.json
@@ -68,6 +68,25 @@
                       "address": "0xffffffffffffffffffffffffffffffffffffffff"
                     }
                   }
+                },
+                "echo": {
+                  "summary": "Simple echo of input data",
+                  "value": {
+                    "accounts": [
+                      {
+                        "address": "0xffffffffffffffffffffffffffffffffffffffff",
+                        "balance": "0x0",
+                        "nonce": 0,
+                        "code": "0x365f5f37365ff3",
+                        "storage": {}
+                      }
+                    ],
+                    "transaction": {
+                      "type": "call",
+                      "address": "0xffffffffffffffffffffffffffffffffffffffff",
+                      "data": "0x1234567890"
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
This PR adds the following:

* Unit tests for a few different types of instructions/scenarios: `selfdestruct`, stack underflow, `keccak256`, `create2`, `call`
* Support for including input `data` in the request body for the `transaction` endpoint
    * An 'echo' example is included in openapi.json that demonstrates the use of the `data` field